### PR TITLE
Update adminPassword to use secureString type

### DIFF
--- a/ais-008/azuredeploy.json
+++ b/ais-008/azuredeploy.json
@@ -14,7 +14,7 @@
             "defaultValue": "azureuser"
         },
         "adminPassword": {
-            "type": "string"
+            "type": "secureString"
         },
         "imageSku": {
             "type": "string",


### PR DESCRIPTION
Following through the lab, I was unable to create a VM using the template. There is a persistent error no matter what you do:

> Passwords must be between 12 and 72 characters and have 3 of the following: 1 lower case, 1 upper case, 1 number, and 1 special character.

Updating the adminPassword parameter to secureString allows the password field to pass validation.